### PR TITLE
Add Firebase phone/Google login page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -1,36 +1,62 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Pump Pal
+
+Pump Pal is a Next.js app with a Firebase-backed login experience that supports phone number verification and Google sign-in.
 
 ## Getting Started
 
-First, run the development server:
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) to view the login page.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Firebase Configuration
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Create a Firebase project and enable **Phone** and **Google** providers in **Authentication → Sign-in method**. Then add the following environment variables (for example in a `.env.local` file):
 
-## Learn More
+```bash
+NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+```
 
-To learn more about Next.js, take a look at the following resources:
+> Phone sign-in requires a reCAPTCHA domain whitelist in your Firebase console. Add your local and production domains there.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Testing and Linting
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+```bash
+npm run lint
+npm run test
+```
 
-## Deploy on Vercel
+## Build
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+```bash
+npm run build
+```
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## OWASP Top 10 Checklist
+
+Use this checklist when shipping to production:
+
+- ✅ **A01: Broken Access Control** — enforce authenticated access to protected routes.
+- ✅ **A02: Cryptographic Failures** — rely on Firebase for token handling and HTTPS-only deployment.
+- ✅ **A03: Injection** — validate and sanitize any user input stored or logged.
+- ✅ **A04: Insecure Design** — ensure MFA or rate-limiting is configured in Firebase where needed.
+- ✅ **A05: Security Misconfiguration** — review Firebase rules and environment variables before deploy.
+- ✅ **A06: Vulnerable Components** — keep dependencies updated and review advisories.
+- ✅ **A07: Identification and Authentication Failures** — enable Firebase Auth providers and protect sessions.
+- ✅ **A08: Software and Data Integrity** — use CI to validate builds and signed deployments.
+- ✅ **A09: Security Logging and Monitoring** — add logging for auth events in production.
+- ✅ **A10: Server-Side Request Forgery** — avoid server-side fetches to untrusted URLs.

--- a/__tests__/LoginPage.test.js
+++ b/__tests__/LoginPage.test.js
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import LoginPage from '@/app/page';
+
+jest.mock('firebase/auth', () => ({
+  RecaptchaVerifier: jest.fn().mockImplementation(() => ({
+    clear: jest.fn()
+  })),
+  signInWithPhoneNumber: jest.fn(),
+  signInWithPopup: jest.fn()
+}));
+
+jest.mock('@/lib/firebase', () => ({
+  auth: {},
+  googleProvider: {}
+}));
+
+describe('LoginPage', () => {
+  it('renders phone and google sign-in options', () => {
+    render(<LoginPage />);
+
+    expect(screen.getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in with google/i })).toBeInTheDocument();
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,171 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background-color: #f4f6fb;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #eef2ff, #f8fafc 60%);
+}
+
+.page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 48px 16px;
+}
+
+.card {
+  width: min(480px, 100%);
+  background: #ffffff;
+  padding: 40px;
+  border-radius: 24px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #64748b;
+  margin: 0;
+}
+
+h1 {
+  margin: 0;
+  font-size: 30px;
+}
+
+.subtitle {
+  margin: 0;
+  color: #475569;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+label {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+input {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  font-size: 15px;
+  outline: none;
+}
+
+input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+button {
+  border: none;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 15px;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.primary {
+  background: #4f46e5;
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.2);
+}
+
+.secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.google {
+  background: #ffffff;
+  color: #0f172a;
+  border: 1px solid #e2e8f0;
+}
+
+.divider {
+  text-align: center;
+  position: relative;
+}
+
+.divider span {
+  background: #fff;
+  padding: 0 12px;
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.divider::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: #e2e8f0;
+  z-index: -1;
+}
+
+.recaptcha {
+  min-height: 78px;
+}
+
+.status {
+  background: #ecfdf5;
+  color: #065f46;
+  padding: 12px;
+  border-radius: 12px;
+  font-size: 14px;
+  margin: 0;
+}
+
+.error {
+  background: #fef2f2;
+  color: #991b1b;
+  padding: 12px;
+  border-radius: 12px;
+  font-size: 14px;
+  margin: 0;
+}
+
+.helper {
+  margin: 0;
+  color: #64748b;
+  font-size: 13px;
+}
+
+@media (max-width: 600px) {
+  .card {
+    padding: 28px;
+  }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,14 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Pump Pal Login',
+  description: 'Sign in with your phone number or Google account.'
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  RecaptchaVerifier,
+  signInWithPhoneNumber,
+  signInWithPopup
+} from 'firebase/auth';
+import { auth, googleProvider } from '@/lib/firebase';
+
+export default function LoginPage() {
+  const recaptchaVerifierRef = useRef(null);
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [verificationCode, setVerificationCode] = useState('');
+  const [confirmation, setConfirmation] = useState(null);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!recaptchaVerifierRef.current && typeof window !== 'undefined') {
+      recaptchaVerifierRef.current = new RecaptchaVerifier(
+        auth,
+        'recaptcha-container',
+        {
+          size: 'normal'
+        }
+      );
+    }
+
+    return () => {
+      if (recaptchaVerifierRef.current) {
+        recaptchaVerifierRef.current.clear();
+        recaptchaVerifierRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleSendCode = async () => {
+    setError('');
+    setStatus('');
+
+    if (!phoneNumber.trim()) {
+      setError('Please enter a phone number with country code, e.g. +1 555 000 0000.');
+      return;
+    }
+
+    try {
+      const confirmationResult = await signInWithPhoneNumber(
+        auth,
+        phoneNumber,
+        recaptchaVerifierRef.current
+      );
+      setConfirmation(confirmationResult);
+      setStatus('Verification code sent. Check your phone.');
+    } catch (err) {
+      setError('Unable to send code. Confirm your phone number and reCAPTCHA.');
+    }
+  };
+
+  const handleVerifyCode = async () => {
+    setError('');
+    setStatus('');
+
+    if (!confirmation) {
+      setError('Request a verification code first.');
+      return;
+    }
+
+    if (!verificationCode.trim()) {
+      setError('Enter the verification code from your phone.');
+      return;
+    }
+
+    try {
+      await confirmation.confirm(verificationCode);
+      setStatus('You are signed in with your phone number.');
+    } catch (err) {
+      setError('The verification code is invalid or expired.');
+    }
+  };
+
+  const handleGoogleSignIn = async () => {
+    setError('');
+    setStatus('');
+
+    try {
+      await signInWithPopup(auth, googleProvider);
+      setStatus('You are signed in with Google.');
+    } catch (err) {
+      setError('Google sign-in failed. Try again.');
+    }
+  };
+
+  return (
+    <main className="page">
+      <section className="card" aria-labelledby="login-title">
+        <div className="header">
+          <p className="eyebrow">Pump Pal</p>
+          <h1 id="login-title">Welcome back</h1>
+          <p className="subtitle">
+            Sign in with your phone number or use Google to continue.
+          </p>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="phone">Phone number</label>
+          <input
+            id="phone"
+            name="phone"
+            type="tel"
+            placeholder="+1 555 000 0000"
+            autoComplete="tel"
+            value={phoneNumber}
+            onChange={(event) => setPhoneNumber(event.target.value)}
+          />
+          <button type="button" className="primary" onClick={handleSendCode}>
+            Send verification code
+          </button>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="code">Verification code</label>
+          <input
+            id="code"
+            name="code"
+            type="text"
+            inputMode="numeric"
+            placeholder="123456"
+            autoComplete="one-time-code"
+            value={verificationCode}
+            onChange={(event) => setVerificationCode(event.target.value)}
+          />
+          <button type="button" className="secondary" onClick={handleVerifyCode}>
+            Verify and sign in
+          </button>
+        </div>
+
+        <div className="divider" role="presentation">
+          <span>or</span>
+        </div>
+
+        <button type="button" className="google" onClick={handleGoogleSignIn}>
+          Sign in with Google
+        </button>
+
+        <div id="recaptcha-container" className="recaptcha" />
+
+        {status ? <p className="status" role="status">{status}</p> : null}
+        {error ? (
+          <p className="error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <p className="helper">
+          Phone sign-in uses Firebase Authentication. Make sure your Firebase
+          project has phone and Google providers enabled.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './'
+});
+
+const customJestConfig = {
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  }
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -1,0 +1,16 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getAuth, GoogleAuthProvider } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
+};
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);
+export const googleProvider = new GoogleAuthProvider();

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "pump-pal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "firebase": "^10.12.2",
+    "next": "14.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/user-event": "^14.5.2",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.5",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a client-side Next.js login screen that supports phone-number (SMS) verification and Google sign-in via Firebase.
- Add a small Firebase initialization helper that reads configuration from environment variables so the app can be wired to any Firebase project.
- Ship basic UI styling, a Jest smoke test for the page, and documentation including setup instructions and an OWASP top-10 checklist.

### Description
- Added a client login page at `app/page.js` implementing phone sign-in with `RecaptchaVerifier`, `signInWithPhoneNumber`, and Google sign-in with `signInWithPopup` and local status/error states.
- Introduced `lib/firebase.js` to initialize Firebase using `NEXT_PUBLIC_*` env vars and export `auth` and `googleProvider`.
- Added UI layout and styling in `app/layout.js` and `app/globals.css`, plus a simple ESLint config in `.eslintrc.json` and `next.config.js` for React strict mode.
- Added test scaffolding with `jest.config.js`, `jest.setup.js`, a mocked unit test at `__tests__/LoginPage.test.js`, updated `package.json` scripts and README with Firebase configuration and an OWASP checklist.

### Testing
- Attempted `npm install`, but dependency installation failed with a registry `403` preventing installing `next`, `jest`, and other packages, so dependencies were not installed and tests could not run.
- Ran `npm run lint` which failed with `sh: 1: next: not found` because dependencies are missing, so linting did not complete successfully.
- Ran `npm run test` which failed with `sh: 1: jest: not found` so the added Jest smoke test (`__tests__/LoginPage.test.js`) was not executed, and `npm run build` also failed for the same missing dependency reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe85c07dc83298f102211ec1ce37a)